### PR TITLE
Different hotkey for linux

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,8 @@
   "commands": {
     "_execute_sidebar_action": {
       "suggested_key": {
-        "default": "Ctrl+Shift+Y"
+        "default": "Ctrl+Shift+Y",
+        "linux": "Ctrl+Alt+C"
       }
     }
   }


### PR DESCRIPTION
Resolves [#25](https://github.com/jamiely/citethis/issues/25)
As mentioned in [issue #25](https://github.com/jamiely/citethis/issues/25), the default hotkey can't be used in Linux, so a different one has to be chosen. 
Feel free to change the keybinding, I choose `ctrl+alt+c` because it seemed free and c for citing